### PR TITLE
Force Net::HTTP::Persistent to not use 3.0

### DIFF
--- a/rapns.gemspec
+++ b/rapns.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "multi_json", "~> 1.0"
-  s.add_dependency "net-http-persistent"
+  s.add_dependency "net-http-persistent", "~> 2.9"
 
   if defined? JRUBY_VERSION
     s.platform = 'java'


### PR DESCRIPTION
Net::HTTP::Persistent v3.0 causes crashes when trying to run the GCM daemon.

/cc @agrberg